### PR TITLE
Fix the bins in Number density analysis

### DIFF
--- a/ramtools/structure/calc_angle_distribution.py
+++ b/ramtools/structure/calc_angle_distribution.py
@@ -21,19 +21,6 @@ def angle_between(v1, v2):
 
     return theta
 
-def s_order_parameter(angles):
-    """ Calculate angle order parameter
-    
-    Parameters
-    ----------
-    angles : list
-        Angle between water and surface in radians
-    """
-    angle_average = np.mean(np.cos(angles)**2)
-    s = (3*angle_average-1) / 2
-
-    return s
-
 def calc_water_angle(trj_file, gro_file, cutoff, dim=2, filepath=''):
     """ Calculate angle distribution between a water molecule vector and normal of
     a surface
@@ -117,83 +104,3 @@ def calc_water_angle(trj_file, gro_file, cutoff, dim=2, filepath=''):
     plt.ylabel('Count')
     plt.xlabel('Angle (Deg)')
     plt.savefig(f'{filepath}/water_angles.pdf')
-
-def calc_water_order_parameter(trj_file, gro_file, cutoffs, dim=2, filepath=''):
-    """ Calculate the order parameter between a water molecule vector and normal of
-    a surface
-    DOI: 10.1021/la0347354
-
-    Water vector:
-
-        ^
-        |
-        |
-
-        O
-       / \
-      H   H
-
-    Parameters
-    ----------
-    trj_file : trajectory file
-        MD trajectory to load
-    gro_file : Coordinate file
-        MD coordinates to load.  MOL2 file is preferred as it contains bond information.
-    cutoff : list or tuple
-        Dimensions of slitpore to consider (angstroms)
-    dim : int
-        Dimension of surface vector
-    """
-    if dim == 0:
-        normal_vector = [1, 0, 0]
-    elif dim == 1:
-        normal_vector = [0, 1, 0]
-    else:
-        normal_vector = [0, 0, 1]
-
-    trj_str = f'{filepath}/{trj_file}'
-    gro_str = f'{filepath}/{gro_file}'
-
-    universe = mda.Universe(gro_str, trj_str)
-
-    water_groups = universe.select_atoms('resname SOL')
-    print("Unwrapping water molecules")
-    transform = transformations.unwrap(water_groups)
-    universe.trajectory.add_transformations(transform)
-    print("Finished unwrapping water molecules")
-    coordinates = [water_groups.positions for ts in universe.trajectory[9000:]]
-    print("Starting to analyze vectors ... ")
-    angle_position = dict()
-    for frame_num, frame in enumerate(coordinates):
-        for idx in np.arange(3,len(frame)+3,3):
-            xyz = frame[idx-3:idx]
-
-            if xyz[0][dim] < cutoffs[0] and xyz[0][dim] > cutoffs[1]:
-                continue
-            # Get midpoint of hydrogens
-            fit = [(xyz[1][i]+xyz[2][i])/2 for i in range(3)]
-            # Draw vector of oxygen going through hydrogen midpoint
-            vector = [xyz[0][i] - fit[i] for i in range(3)]
-
-            angle = angle_between(np.array([vector[0], vector[1], vector[2]]),
-                    np.array(normal_vector)) * (180 / np.pi)
-
-            angle_in_radians = angle * np.pi / 180
-            angle_position[xyz[0][dim]] = angle_in_radians
-
-    distance_dict = dict()
-    for dis in np.arange(cutoffs[0], cutoffs[1], step=0.1):
-        distance_dict[dis] = list()
-        for pos, angle in angle_position.items():
-            if pos > dis and pos < (dis+1):
-                distance_dict[dis].append(angle)
-
-    s_order_dict = dict()
-    for dis, angles in distance_dict.items():
-        s_order_dict[dis] = s_order_parameter(angles)
-
-    fig, ax = plt.subplots()
-    plt.plot(s_order_dict.keys(), s_order_dict.values())
-    plt.xlabel('Distance')
-    plt.ylabel('S')
-    plt.savefig(f'{filepath}/s_order.pdf')

--- a/ramtools/structure/calc_angle_distribution.py
+++ b/ramtools/structure/calc_angle_distribution.py
@@ -21,6 +21,19 @@ def angle_between(v1, v2):
 
     return theta
 
+def s_order_parameter(angles):
+    """ Calculate angle order parameter
+    
+    Parameters
+    ----------
+    angles : list
+        Angle between water and surface in radians
+    """
+    angle_average = np.mean(np.cos(angles)**2)
+    s = (3*angle_average-1) / 2
+
+    return s
+
 def calc_water_angle(trj_file, gro_file, cutoff, dim=2, filepath=''):
     """ Calculate angle distribution between a water molecule vector and normal of
     a surface
@@ -104,3 +117,83 @@ def calc_water_angle(trj_file, gro_file, cutoff, dim=2, filepath=''):
     plt.ylabel('Count')
     plt.xlabel('Angle (Deg)')
     plt.savefig(f'{filepath}/water_angles.pdf')
+
+def calc_water_order_parameter(trj_file, gro_file, cutoffs, dim=2, filepath=''):
+    """ Calculate the order parameter between a water molecule vector and normal of
+    a surface
+    DOI: 10.1021/la0347354
+
+    Water vector:
+
+        ^
+        |
+        |
+
+        O
+       / \
+      H   H
+
+    Parameters
+    ----------
+    trj_file : trajectory file
+        MD trajectory to load
+    gro_file : Coordinate file
+        MD coordinates to load.  MOL2 file is preferred as it contains bond information.
+    cutoff : list or tuple
+        Dimensions of slitpore to consider (angstroms)
+    dim : int
+        Dimension of surface vector
+    """
+    if dim == 0:
+        normal_vector = [1, 0, 0]
+    elif dim == 1:
+        normal_vector = [0, 1, 0]
+    else:
+        normal_vector = [0, 0, 1]
+
+    trj_str = f'{filepath}/{trj_file}'
+    gro_str = f'{filepath}/{gro_file}'
+
+    universe = mda.Universe(gro_str, trj_str)
+
+    water_groups = universe.select_atoms('resname SOL')
+    print("Unwrapping water molecules")
+    transform = transformations.unwrap(water_groups)
+    universe.trajectory.add_transformations(transform)
+    print("Finished unwrapping water molecules")
+    coordinates = [water_groups.positions for ts in universe.trajectory[9000:]]
+    print("Starting to analyze vectors ... ")
+    angle_position = dict()
+    for frame_num, frame in enumerate(coordinates):
+        for idx in np.arange(3,len(frame)+3,3):
+            xyz = frame[idx-3:idx]
+
+            if xyz[0][dim] < cutoffs[0] and xyz[0][dim] > cutoffs[1]:
+                continue
+            # Get midpoint of hydrogens
+            fit = [(xyz[1][i]+xyz[2][i])/2 for i in range(3)]
+            # Draw vector of oxygen going through hydrogen midpoint
+            vector = [xyz[0][i] - fit[i] for i in range(3)]
+
+            angle = angle_between(np.array([vector[0], vector[1], vector[2]]),
+                    np.array(normal_vector)) * (180 / np.pi)
+
+            angle_in_radians = angle * np.pi / 180
+            angle_position[xyz[0][dim]] = angle_in_radians
+
+    distance_dict = dict()
+    for dis in np.arange(cutoffs[0], cutoffs[1], step=0.1):
+        distance_dict[dis] = list()
+        for pos, angle in angle_position.items():
+            if pos > dis and pos < (dis+1):
+                distance_dict[dis].append(angle)
+
+    s_order_dict = dict()
+    for dis, angles in distance_dict.items():
+        s_order_dict[dis] = s_order_parameter(angles)
+
+    fig, ax = plt.subplots()
+    plt.plot(s_order_dict.keys(), s_order_dict.values())
+    plt.xlabel('Distance')
+    plt.ylabel('S')
+    plt.savefig(f'{filepath}/s_order.pdf')

--- a/ramtools/structure/calc_number_density.py
+++ b/ramtools/structure/calc_number_density.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 
 
 def calc_number_density(trj, area,
-        dim, box_range, n_bins, frame_range=None,maxs=None, mins=None):
+        dim, box_range, n_bins, shift=True, frame_range=None, maxs=None, mins=None):
     """
     Calculate a 1-dimensional number density profile for each residue
 
@@ -24,6 +24,8 @@ def calc_number_density(trj, area,
         Range of coordinates in 'dim' to evaluate
     n_bins : int
         Number of bins in histogram
+    shift : boolean, default=True
+        Shift bins to zero if True
     frame_range : Python range() (optional)
         Range of frames to calculate number density function over
     maxs : array (optional)
@@ -90,9 +92,17 @@ def calc_number_density(trj, area,
         rho_list.append(rho)
         res_list.append(resname)
 
-    bin_list = bins[:-1]
+    new_bins = list()
+    for idx, bi in enumerate(bins):
+        if (idx+1) >= len(bins):
+            continue
+        mid = (bins[idx] + bins[idx+1])/2
+        new_bins.append(mid)
+
+    if shift:
+        new_bins = [(bi-new_bins[0]) for bi in new_bins]
     
-    return (rho_list, bin_list, res_list)
+    return (rho_list, new_bins, res_list)
 
 def calc_number_lammps(lammpstrj, top_file, area,
         dim, box_range, n_bins, frame_range=None,maxs=None, mins=None):

--- a/ramtools/structure/calc_number_density.py
+++ b/ramtools/structure/calc_number_density.py
@@ -25,7 +25,7 @@ def calc_number_density(trj, area,
     n_bins : int
         Number of bins in histogram
     shift : boolean, default=True
-        Shift bins to zero if True
+        Shift center to zero if True
     frame_range : Python range() (optional)
         Range of frames to calculate number density function over
     maxs : array (optional)
@@ -100,7 +100,12 @@ def calc_number_density(trj, area,
         new_bins.append(mid)
 
     if shift:
-        new_bins = [(bi-new_bins[0]) for bi in new_bins]
+        middle = float(n_bins / 2)
+        if middle % 2 != 0:
+            shift_value = new_bins[int(middle - 0.5)]
+        else:
+            shift_value = new_bins[int(middle)]
+        new_bins = [(bi-shift_value) for bi in new_bins]
     
     return (rho_list, new_bins, res_list)
 

--- a/ramtools/tests/base_test.py
+++ b/ramtools/tests/base_test.py
@@ -13,3 +13,9 @@ class BaseTest:
         trj = md.load(get_fn('tip3p.xtc'), top=get_fn('tip3p.gro'))
 
         return trj
+
+    @pytest.fixture
+    def gph_pore(self):
+        trj = md.load(get_fn('nvt_small.trr'), top=get_fn('nvt.gro'))
+  
+        return trj

--- a/ramtools/tests/test_structure.py
+++ b/ramtools/tests/test_structure.py
@@ -7,12 +7,18 @@ from ramtools.utils.io import get_fn
 
 
 class TestStructure(BaseTest):
-    def test_number_density(self, water_trj):
-        area = water_trj.unitcell_lengths[0][0] * water_trj.unitcell_lengths[0][1]
-        dim = 2
-        box_range = [0, 1]
-        n_bins = 5
+    @pytest.mark.parametrize("n_bins, shift", [(100, True), (100, False), (101, True), (101, False)])
+    def test_number_density(self, gph_pore, n_bins, shift):
+        area = gph_pore.unitcell_lengths[0][0] * gph_pore.unitcell_lengths[0][1]
+        dim = 1
+        box_range = [0.837, 2.837]
+        n_bins = n_bins
 
         calc_number_density.calc_number_density(
-            water_trj, area=area, dim=dim, box_range=box_range, n_bins=n_bins
+            gph_pore, 
+            area=area,
+            dim=dim,
+            shift=shift,
+            box_range=box_range,
+            n_bins=n_bins
         )


### PR DESCRIPTION
Addressing #22, the center of the bins are used for plotting the number density function.  An optional `shift` argument has been added to shift the bins to zero if `True`.  